### PR TITLE
P25Spec would only accept the original list as opposed to any permutation

### DIFF
--- a/exercises/src/test/scala/pl/japila/scalania/s99/P25Spec.scala
+++ b/exercises/src/test/scala/pl/japila/scalania/s99/P25Spec.scala
@@ -11,7 +11,7 @@ class P25Spec extends Specification with ExamplesBlock {
           solution >> {
             val input = List('a, 'b, 'c, 'd, 'e, 'f)
             val randomPer = randomPermuteImpl(input)
-            randomPer.intersect(input) === input
+            input.intersect(randomPer) === input
             randomPer.diff(input).size === 0
           }
       }


### PR DESCRIPTION
I believe a condition in P25Spec is invalid. I got this output after implementing the exercise.

```
Expected :List('a, 'b, 'c, 'd, 'e, 'f)
Actual   :List('b, 'd, 'e, 'a, 'c, 'f)
```

The way it was written, it would only accept the original list as a correct solution. Any other permutation would result in a test failure. I took the liberty of modifying the condition to accept any valid permutation.

Hope this is OK,
Cheers
