### PR TITLE
Added solution for collection/P04

### DIFF
--- a/exercises/src/main/scala/pl/japila/scalania/collection/P04.scala
+++ b/exercises/src/main/scala/pl/japila/scalania/collection/P04.scala
@@ -1,5 +1,19 @@
 package pl.japila.scalania.collection
 
 object P04 {
-  def groupIndexed[T](m: Map[T, Int]): Map[T, Seq[Int]] = ???
+  def groupIndexed[T](m: Seq[(T, Int)]): Map[T, Seq[Int]] = {
+    def numToIndices(num: Int): Seq[Int] = {
+      if (num > 1) 0 +: numToIndices(num - 1)
+      else Seq(1)
+    }
+
+    def mapToIndices[T](lastProcced: Int, s: Seq[Int]): Seq[Int] = {
+      s match {
+        case head +: tail => numToIndices(head - lastProcced) ++ mapToIndices(head, tail)
+        case Seq() => s
+      }
+    }
+
+    m.groupBy(_._1).mapValues(_.map(_._2)).mapValues(xs => mapToIndices(0, xs.sorted))
+  }
 }

--- a/exercises/src/test/scala/pl/japila/scalania/collection/P04Spec.scala
+++ b/exercises/src/test/scala/pl/japila/scalania/collection/P04Spec.scala
@@ -7,17 +7,17 @@ class P04Spec extends Specification {
   "groupIndexed" should {
     "Group keys and use their values as indices." in {
       {
-        val input = Map(
+        val input = Seq(
           1 -> 2,
-          1 -> 3,
           1 -> 5,
-          2 -> 1,
+          1 -> 3,
+          2 -> 4,
           2 -> 3,
-          2 -> 4
+          2 -> 1
         )
         val expected = Map(
           1 -> Seq(0, 1, 1, 0, 1),
-          2 -> Seq(1, 0, 1, 1, 0)
+          2 -> Seq(1, 0, 1, 1)
         )
         groupIndexed(input) must_=== expected
       }


### PR DESCRIPTION
- GroupIndexed function definition changed from groupIndexed[T](m: Map[T, Int]) => groupIndexed[T](m: Seq[(T, Int)])
- I think that function shouldn't return 0 in Indexed Seq after last 1 element.